### PR TITLE
Minor changes to support rxjava2 from propeller-core

### DIFF
--- a/src/main/scala/org/adridadou/propeller/scala/ScalaEthereumEventHandler.scala
+++ b/src/main/scala/org/adridadou/propeller/scala/ScalaEthereumEventHandler.scala
@@ -1,11 +1,10 @@
 package org.adridadou.propeller.scala
 
+import io.reactivex.Observable
 import org.adridadou.ethereum.propeller.event.{BlockInfo, EthereumEventHandler}
 import org.adridadou.ethereum.propeller.values.TransactionInfo
-import rx.lang.scala.Observable
 
 import scala.concurrent.Future
-import rx.lang.scala.JavaConversions._
 
 /**
   * Created by davidroon on 18.04.17.

--- a/src/main/scala/org/adridadou/propeller/scala/ScalaEthereumFacade.scala
+++ b/src/main/scala/org/adridadou/propeller/scala/ScalaEthereumFacade.scala
@@ -1,5 +1,6 @@
 package org.adridadou.propeller.scala
 
+import io.reactivex.Observable
 import org.adridadou.ethereum.propeller.EthereumFacade
 import org.adridadou.ethereum.propeller.solidity.converters.SolidityTypeGroup
 import org.adridadou.ethereum.propeller.solidity.{SolidityContractDetails, SolidityEvent, SolidityType}
@@ -7,11 +8,8 @@ import org.adridadou.ethereum.propeller.swarm.SwarmHash
 import org.adridadou.ethereum.propeller.values._
 import org.adridadou.propeller.scala.decoders.ScalaNumberDecoder
 import org.adridadou.propeller.scala.encoders.ScalaNumberEncoder
-import rx.lang.scala.Observable
 
 import scala.compat.java8.OptionConverters._
-import rx.lang.scala.JavaConversions._
-
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.reflect.ClassTag


### PR DESCRIPTION
- [x] Updated Observable classes from RxJava1 to io.reactivex.Observable from RxJava2 which is returned by the propeller-core lib.

This PR depends on https://github.com/adridadou/eth-propeller-core/pull/27